### PR TITLE
Fix autocorrect for nested pack dependency violations

### DIFF
--- a/src/codeActionProvider.ts
+++ b/src/codeActionProvider.ts
@@ -126,7 +126,8 @@ export class PackwerkCodeActionProvider implements vscode.CodeActionProvider {
   ): { sourcePack: string; targetPack: string } | undefined {
     // Try to extract pack names from message
     // Example with backticks: "belongs to `packs/foo`, but `packs/bar/package.yml` does not"
-    const matchBackticks = message.match(/belongs to `([^`]+)`,.*?`([^`\/]+(?:\/[^`\/]+)?)/);
+    // For nested packs: "belongs to `packs/foo`, but `packs/bar/app/domain/calculators/package.yml` does not"
+    const matchBackticks = message.match(/belongs to `([^`]+)`,.*?`([^`]+?)\/package\.yml`/);
     if (matchBackticks) {
       return { sourcePack: matchBackticks[2], targetPack: matchBackticks[1] };
     }


### PR DESCRIPTION
The regex pattern was only capturing up to 2 path segments (e.g., packs/tap), which meant nested packs like packs/tap/app/domain/calculators were being truncated to their parent pack. This caused the add-dependency code action to add the dependency to the wrong package.yml file.

Updated the regex to extract the full pack path by matching everything before /package.yml, which correctly handles both simple and nested packs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Committed-By-Agent: claude