### PR TITLE
Use pks check --json instead of regex parsing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,4 @@
+# Development
+
+- After every change, bump the version in `package.json` and compile a new `.vsix` for local install: `npx vsce package`
+- Run `npx tsc --noEmit` to type check before committing

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pks-vscode",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "publisher": "alexevanczuk",
   "displayName": "Pks",
   "description": "execute pks check for current Ruby code.",

--- a/src/outputParser.ts
+++ b/src/outputParser.ts
@@ -1,36 +1,5 @@
-import { PackwerkOutput, PackwerkFile } from './packwerkOutput';
-
-const regex = /^(?<file>[^\n]*?):(?<row>\d+):(?<column>\d+)$(?<message>.*?::(?<symbol>.*?)['| ].*?)^\s?$/gms;
+import { PackwerkOutput } from './packwerkOutput';
 
 export function parseOutput(str: string): PackwerkOutput {
-  try {
-    return JSON.parse(str);
-  } catch {
-    const files = new Map<string, PackwerkFile>();
-
-    let arr: RegExpExecArray;
-    while ((arr = regex.exec(str)) !== null) {
-      console.log("[DEBUG] Parsed regular expression", arr)
-      const file = arr[1];
-      const line = Number(arr[2]);
-      const column = Number(arr[3]);
-      const message = arr[4].trim();
-      const symbol = arr[5];
-
-      if (!files.has(file)) files.set(file, { path: file, violations: [] });
-
-      files.get(file)!.violations.push({
-        message,
-        location: {
-          line,
-          column,
-          length: symbol.length,
-        },
-      });
-    }
-
-    return {
-      files: Array.from(files.values()),
-    };
-  }
+  return JSON.parse(str);
 }

--- a/src/packwerkOutput.ts
+++ b/src/packwerkOutput.ts
@@ -1,19 +1,16 @@
-interface PackwerkLocation {
-  line: number;
-  column: number;
-  length: number;
-}
-
 export interface PackwerkViolation {
   message: string;
-  location: PackwerkLocation;
-}
-
-export interface PackwerkFile {
-  path: string;
-  violations: Array<PackwerkViolation>;
+  file: string;
+  line: number;
+  column: number;
+  violation_type: string;
+  strict: boolean;
+  constant_name: string;
+  referencing_pack_name: string;
+  defining_pack_name: string;
 }
 
 export interface PackwerkOutput {
-  files: Array<PackwerkFile>;
+  status: string;
+  violations: Array<PackwerkViolation>;
 }


### PR DESCRIPTION
## Summary

- All `pks check` commands now pass `--json` and parse structured JSON output directly
- Removes the fragile regex parser and ANSI color stripping from `outputParser.ts`
- Updates `PackwerkOutput` types to match the flat `{ status, violations[] }` format from `pks check --json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)