### PR TITLE
Add Go to package.yml command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pks-vscode",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "publisher": "alexevanczuk",
   "displayName": "Pks",
   "description": "execute pks check for current Ruby code.",
@@ -51,6 +51,10 @@
       {
         "command": "ruby.packwerk.all",
         "title": "Pks: Run pks check (all files)"
+      },
+      {
+        "command": "ruby.packwerk.goToPackageYml",
+        "title": "Pks: Go to package.yml"
       }
     ],
     "configuration": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,6 +30,40 @@ export function activate(context: vscode.ExtensionContext): void {
     })
   );
 
+  // Register command to go to package.yml for current file
+  context.subscriptions.push(
+    vscode.commands.registerCommand('ruby.packwerk.goToPackageYml', () => {
+      const editor = vscode.window.activeTextEditor;
+      if (!editor) {
+        vscode.window.showErrorMessage('No active editor');
+        return;
+      }
+
+      const cwd = vscode.workspace.rootPath;
+      if (!cwd) {
+        vscode.window.showErrorMessage('No workspace folder open');
+        return;
+      }
+
+      const filePath = editor.document.fileName;
+      const relativePath = filePath.replace(cwd + '/', '');
+      const command = `pks for-file ${relativePath}`;
+
+      exec(command, { cwd }, (error: Error | null, stdout: string, stderr: string) => {
+        if (error) {
+          vscode.window.showErrorMessage(`Could not find package.yml: ${stderr || error.message}`);
+          return;
+        }
+
+        const packageYmlPath = stdout.trim();
+        if (packageYmlPath) {
+          const uri = vscode.Uri.file(packageYmlPath);
+          vscode.window.showTextDocument(uri);
+        }
+      });
+    })
+  );
+
   // Register code action provider
   const codeActionProvider = new PackwerkCodeActionProvider();
   context.subscriptions.push(


### PR DESCRIPTION
Adds a "Pks: Go to package.yml" command that navigates to the package.yml that owns the current file.

Requires pks 0.2.34+ which adds the `for-file` command.

Generated with [Claude Code](https://claude.com/claude-code)