### PR TITLE
Add clickable constant links in package_todo.yml

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pks-vscode",
-  "version": "0.0.30",
+  "version": "0.0.32",
   "publisher": "alexevanczuk",
   "displayName": "Pks",
   "description": "execute pks check for current Ruby code.",
@@ -57,6 +57,10 @@
       {
         "command": "ruby.pks.goToPackageYml",
         "title": "Pks: Go to package.yml"
+      },
+      {
+        "command": "ruby.pks.refreshDefinitions",
+        "title": "Pks: Refresh constant definitions"
       }
     ],
     "configuration": {

--- a/src/constantDefinitionCache.ts
+++ b/src/constantDefinitionCache.ts
@@ -1,0 +1,76 @@
+import * as vscode from 'vscode';
+import { exec } from 'child_process';
+
+export class ConstantDefinitionCache {
+  private cache: Map<string, string> = new Map();
+  private isLoading: boolean = false;
+  private outputChannel: vscode.OutputChannel;
+
+  constructor(outputChannel: vscode.OutputChannel) {
+    this.outputChannel = outputChannel;
+  }
+
+  private log(message: string): void {
+    const timestamp = new Date().toISOString();
+    this.outputChannel.appendLine(`[${timestamp}] ${message}`);
+  }
+
+  public getDefinitionPath(constantName: string): string | undefined {
+    // Normalize constant name - ensure it starts with ::
+    const normalized = constantName.startsWith('::') ? constantName : `::${constantName}`;
+    return this.cache.get(normalized);
+  }
+
+  public isReady(): boolean {
+    return this.cache.size > 0 && !this.isLoading;
+  }
+
+  public refresh(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const cwd = vscode.workspace.rootPath;
+      if (!cwd) {
+        this.log('ConstantDefinitionCache: No workspace folder open');
+        reject(new Error('No workspace folder open'));
+        return;
+      }
+
+      if (this.isLoading) {
+        this.log('ConstantDefinitionCache: Already loading, skipping');
+        resolve();
+        return;
+      }
+
+      this.isLoading = true;
+      this.log('ConstantDefinitionCache: Loading definitions...');
+
+      const command = 'pks list-definitions';
+      exec(command, { cwd, maxBuffer: 50 * 1024 * 1024 }, (error, stdout, stderr) => {
+        this.isLoading = false;
+
+        if (error) {
+          this.log(`ConstantDefinitionCache: Error running pks list-definitions: ${stderr || error.message}`);
+          reject(error);
+          return;
+        }
+
+        this.cache.clear();
+        const lines = stdout.split('\n');
+        let count = 0;
+
+        for (const line of lines) {
+          // Parse: "::ConstantName" is defined at "path/to/file.rb"
+          const match = line.match(/^"(::[\w:]+)" is defined at "([^"]+)"$/);
+          if (match) {
+            const constantName = match[1];
+            const filePath = match[2];
+            this.cache.set(constantName, filePath);
+            count++;
+          }
+        }
+
+        this.log(`ConstantDefinitionCache: Loaded ${count} definitions`);
+        resolve();
+      });
+    });
+  }
+}


### PR DESCRIPTION
Constants like `"::Foo::Bar":` in package_todo.yml are now clickable and will open the file where the constant is defined.

- Uses `pks list-definitions` to build a cache on activation
- Add "Pks: Refresh constant definitions" command to rebuild the cache

Generated with [Claude Code](https://claude.com/claude-code)