### PR TITLE
Add toggle highlight violations command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pks-vscode",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "publisher": "alexevanczuk",
   "displayName": "Pks",
   "description": "execute pks check for current Ruby code.",
@@ -61,6 +61,10 @@
       {
         "command": "ruby.pks.refreshDefinitions",
         "title": "Pks: Refresh constant definitions"
+      },
+      {
+        "command": "ruby.pks.toggleHighlightViolations",
+        "title": "Pks: Toggle highlight violations"
       }
     ],
     "configuration": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pks-vscode",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "publisher": "alexevanczuk",
   "displayName": "Pks",
   "description": "execute pks check for current Ruby code.",

--- a/src/codeActionProvider.ts
+++ b/src/codeActionProvider.ts
@@ -23,6 +23,9 @@ export class PackwerkCodeActionProvider implements vscode.CodeActionProvider {
       const shortRefPack = this.shortenPackName(metadata.referencing_pack_name);
       const shortDefPack = this.shortenPackName(metadata.defining_pack_name);
 
+      // Check if this is a highlight diagnostic (already recorded violation)
+      const isHighlight = diagnostic.severity === vscode.DiagnosticSeverity.Information;
+
       // 1. First action depends on violation type
       if (metadata.violation_type === 'dependency') {
         // Add: foo -> bar
@@ -38,17 +41,20 @@ export class PackwerkCodeActionProvider implements vscode.CodeActionProvider {
         actions.push(this.createMakePublicAction(diagnostic, metadata.constant_name));
       }
 
-      // 2. todo: this file -> ::Bar
-      actions.push(this.createTodoFileAction(diagnostic, metadata));
+      // Todo actions only for new violations (errors), not for highlights
+      if (!isHighlight) {
+        // 2. todo: this file -> ::Bar
+        actions.push(this.createTodoFileAction(diagnostic, metadata));
 
-      // 3. todo: foo -> ::Bar
-      actions.push(this.createTodoPackConstantAction(diagnostic, metadata, shortRefPack));
+        // 3. todo: foo -> ::Bar
+        actions.push(this.createTodoPackConstantAction(diagnostic, metadata, shortRefPack));
 
-      // 4. todo: foo -> bar
-      actions.push(this.createTodoPackToPackAction(diagnostic, metadata, shortRefPack, shortDefPack));
+        // 4. todo: foo -> bar
+        actions.push(this.createTodoPackToPackAction(diagnostic, metadata, shortRefPack, shortDefPack));
 
-      // 5. todo: all
-      actions.push(this.createTodoAllAction(diagnostic));
+        // 5. todo: all
+        actions.push(this.createTodoAllAction(diagnostic));
+      }
     }
 
     return actions;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,6 +15,13 @@ export function activate(context: vscode.ExtensionContext): void {
   const diag = vscode.languages.createDiagnosticCollection('ruby');
   context.subscriptions.push(diag);
 
+  // Separate diagnostic collection for highlight mode (blue hints)
+  const highlightDiag = vscode.languages.createDiagnosticCollection('ruby-highlights');
+  context.subscriptions.push(highlightDiag);
+
+  // Track highlight toggle state
+  let highlightsEnabled = false;
+
   const outputChannel = vscode.window.createOutputChannel('Pks');
   context.subscriptions.push(outputChannel);
 
@@ -130,6 +137,24 @@ export function activate(context: vscode.ExtensionContext): void {
           vscode.window.showInformationMessage('Constant definitions refreshed');
         }
       );
+    })
+  );
+
+  // Register command to toggle highlight violations
+  context.subscriptions.push(
+    vscode.commands.registerCommand('ruby.pks.toggleHighlightViolations', () => {
+      highlightsEnabled = !highlightsEnabled;
+
+      if (highlightsEnabled) {
+        vscode.window.showInformationMessage('Pks: Highlight violations enabled');
+        packwerk.executeAllToCollection(
+          highlightDiag,
+          vscode.DiagnosticSeverity.Hint
+        );
+      } else {
+        vscode.window.showInformationMessage('Pks: Highlight violations disabled');
+        highlightDiag.clear();
+      }
     })
   );
 

--- a/src/packwerk.ts
+++ b/src/packwerk.ts
@@ -143,6 +143,17 @@ export class Packwerk {
           vscode.DiagnosticSeverity.Information
         );
         diagnostic.source = 'packwerk';
+
+        // Attach violation metadata for code actions
+        const metadata: ViolationMetadata = {
+          file: offence.file,
+          violation_type: offence.violation_type,
+          constant_name: offence.constant_name,
+          referencing_pack_name: offence.referencing_pack_name,
+          defining_pack_name: offence.defining_pack_name,
+        };
+        (diagnostic as any)._packwerk = metadata;
+
         diagnostics.push(diagnostic);
       });
 


### PR DESCRIPTION
## Summary
- Adds "Pks: Toggle highlight violations" command (cmd+shift+p)
- When enabled, shows violations as blue hint underlines alongside existing error diagnostics
- When disabled, clears the hint highlights (errors remain)

Similar to Sorbet's "Toggle highlight untyped code" feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)