### PR TITLE
Remove manual single-file pks check command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pks-vscode",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "publisher": "alexevanczuk",
   "displayName": "Pks",
   "description": "execute pks check for current Ruby code.",
@@ -19,8 +19,7 @@
   "activationEvents": [
     "onLanguage:ruby",
     "onLanguage:yaml",
-    "workspaceContains:**/package.yml",
-    "onCommand:ruby.pks"
+    "workspaceContains:**/package.yml"
   ],
   "main": "./out/src/extension",
   "scripts": {
@@ -46,10 +45,6 @@
       }
     ],
     "commands": [
-      {
-        "command": "ruby.pks",
-        "title": "Pks: Run pks check"
-      },
       {
         "command": "ruby.pks.all",
         "title": "Pks: Run pks check (all files)"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -38,17 +38,6 @@ export function activate(context: vscode.ExtensionContext): void {
   constantCache.refresh().catch(() => {
     // Silently ignore errors on initial load
   });
-  const disposable = vscode.commands.registerCommand('ruby.pks', () => {
-    const editor = vscode.window.activeTextEditor;
-    if (!editor) {
-      vscode.window.showErrorMessage('No active editor');
-      return;
-    }
-    outputChannel.show(true);
-    packwerk.execute(editor.document);
-  });
-
-  context.subscriptions.push(disposable);
 
   // Register command to run pks check on all files
   context.subscriptions.push(


### PR DESCRIPTION
## Summary
- Remove "Pks: Run pks check" command since pks check runs automatically on save
- Keep "Pks: Run pks check (all files)" for full repo checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)