### PR TITLE
Fix VS Code installation instructions for Open VSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ A VS Code extension for [pks](https://github.com/alexevanczuk/packs), a tool for
 Install from [Open VSX](https://open-vsx.org/extension/alexevanczuk/pks-vscode):
 
 ```bash
-# VS Code
-code --install-extension alexevanczuk.pks-vscode
-
 # Cursor
 cursor --install-extension alexevanczuk.pks-vscode
+
+# VS Code
+curl -sL $(curl -s https://open-vsx.org/api/alexevanczuk/pks-vscode/latest | jq -r .files.download) -o /tmp/pks.vsix && code --install-extension /tmp/pks.vsix
 ```
 
 ## Features


### PR DESCRIPTION
## Summary
- VS Code doesn't natively pull from Open VSX, so provide a curl one-liner to download and install
- Put Cursor first since it works directly with Open VSX

🤖 Generated with [Claude Code](https://claude.com/claude-code)