### PR TITLE
Add cyclic dependency diagnostics and remove-dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pks-vscode",
-  "version": "0.0.39",
+  "version": "0.0.40",
   "publisher": "alexevanczuk",
   "displayName": "Pks",
   "description": "execute pks check for current Ruby code.",

--- a/src/pksOutput.ts
+++ b/src/pksOutput.ts
@@ -25,3 +25,28 @@ export interface ViolationMetadata {
   referencing_pack_name: string;
   defining_pack_name: string;
 }
+
+// Types for pks validate --json output
+export interface CycleEdge {
+  from_pack: string;
+  to_pack: string;
+  file: string;
+}
+
+export interface ValidationError {
+  error_type: string;
+  message: string;
+  cycle_edges?: CycleEdge[];
+  file?: string;
+}
+
+export interface PksValidateOutput {
+  status: string;
+  validation_errors: ValidationError[];
+}
+
+// Metadata stored on cycle diagnostics for code actions
+export interface CycleDiagnosticMetadata {
+  from_pack: string;
+  to_pack: string;
+}

--- a/test/pks.ts
+++ b/test/pks.ts
@@ -5,12 +5,14 @@ import { Pks } from '../src/pks';
 describe('Pks', () => {
   let instance: Pks;
   let diagnostics: vscode.DiagnosticCollection;
+  let validateDiagnostics: vscode.DiagnosticCollection;
   let outputChannel: vscode.OutputChannel;
 
   beforeEach(() => {
     diagnostics = vscode.languages.createDiagnosticCollection();
+    validateDiagnostics = vscode.languages.createDiagnosticCollection();
     outputChannel = vscode.window.createOutputChannel('Pks Test');
-    instance = new Pks(diagnostics, outputChannel);
+    instance = new Pks(diagnostics, validateDiagnostics, outputChannel);
   });
 
   describe('initialization', () => {


### PR DESCRIPTION
## Summary
- Red squiggly underlines on dependency lines in `package.yml` that participate in cycles
- `executeValidate()` runs `pks validate --json` and parses structured cycle data
- Quick fix code action to remove a cyclic dependency via `pks remove-dependency`
- `executeAll()` now runs both check and validate
- `package.yml` saves trigger cycle re-validation

Depends on: https://github.com/alexevanczuk/packs/pull/247

🤖 Generated with [Claude Code](https://claude.com/claude-code)