### PR TITLE
Refresh diagnostics when saving package.yml/package_todo.yml

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pks-vscode",
-  "version": "0.0.39",
+  "version": "0.0.40",
   "publisher": "alexevanczuk",
   "displayName": "Pks",
   "description": "execute pks check for current Ruby code.",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -398,7 +398,18 @@ export function activate(context: vscode.ExtensionContext): void {
   pks.executeAll();
 
   ws.onDidSaveTextDocument((e: vscode.TextDocument) => {
-    if (pks.isOnSave) {
+    if (!pks.isOnSave) {
+      return;
+    }
+
+    // Saving package.yml / package_todo.yml can affect violations in *other*
+    // files (adding a dependency, recording/removing a todo, making a constant
+    // public). A single-file check can't catch those, so do a whole-workspace
+    // recheck. Ruby/gemfile saves keep the fast single-file check.
+    const baseName = e.fileName.split('/').pop() || '';
+    if (baseName === 'package.yml' || baseName === 'package_todo.yml') {
+      pks.executeAll();
+    } else {
       pks.execute(e);
     }
   });


### PR DESCRIPTION
On-save auto-refresh only re-checked the single saved ruby file, so cross-file fixes (adding a dependency, recording/removing a todo, making a constant public) never re-checked the file where the violation is displayed — leaving stale entries in the Problems panel.

This makes saving a `package.yml` / `package_todo.yml` run a whole-workspace recheck (`executeAll`), while ruby/gemfile saves keep the fast single-file check.

Version bumped to 0.0.40 so the release workflow publishes to Open VSX on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)