### PR TITLE
Bump to 0.0.41 to publish save-refresh fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pks-vscode",
-  "version": "0.0.40",
+  "version": "0.0.41",
   "publisher": "alexevanczuk",
   "displayName": "Pks",
   "description": "execute pks check for current Ruby code.",


### PR DESCRIPTION
Bump 0.0.40 → 0.0.41.

`v0.0.40` was already tagged (from a prior build), so when #21 merged, the release workflow's tag-exists check skipped Package/Publish/Create-Release — the on-save refresh fix never reached Open VSX (which still serves the old 0.0.40). Bumping to an untagged version so the publish actually runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)