### PR TITLE
Fail release when bumped version collides with existing tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,30 @@ jobs:
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Check if version changed in this push
+        id: version_changed
+        run: |
+          before="${{ github.event.before }}"
+          changed=true
+          # A no-parent / brand-new push has no meaningful "before"; treat as changed.
+          if [ -n "$before" ] && [ "$before" != "0000000000000000000000000000000000000000" ] && git cat-file -e "$before:package.json" 2>/dev/null; then
+            git show "$before:package.json" > /tmp/prev-package.json
+            prev=$(node -p "require('/tmp/prev-package.json').version")
+            if [ "$prev" = "${{ steps.package_version.outputs.version }}" ]; then
+              changed=false
+            fi
+          fi
+          echo "changed=$changed" >> $GITHUB_OUTPUT
+
+      # Guard: catch the silent-skip trap where package.json is bumped to a
+      # version whose tag already exists (publish would otherwise be skipped and
+      # the release job would still report success). Fail loudly instead.
+      - name: Fail if bumped version collides with an existing tag
+        if: steps.version_changed.outputs.changed == 'true' && steps.tag_exists.outputs.exists == 'true'
+        run: |
+          echo "::error::package.json version was changed to ${{ steps.package_version.outputs.version }} in this push, but tag v${{ steps.package_version.outputs.version }} already exists. Bump to a new, untagged version."
+          exit 1
+
       - name: Package extension
         if: steps.tag_exists.outputs.exists == 'false'
         run: npx @vscode/vsce package --no-yarn

--- a/dev.md
+++ b/dev.md
@@ -5,8 +5,24 @@ This is a collection of some relatively unorganized notes for people interested 
   - possibly allow for updating a single file rather than a pack. This would require changes to pks to support update-deprecations working correctly on a single file.
 - click to open public API where constant lives
 
+## Releasing a new version
+
+Publishing is automated by `.github/workflows/release.yml`, which runs on every push to `main`.
+
+To cut a release:
+1. Bump `version` in `package.json` to a **new** value (one that has never been released).
+2. Merge to `main`.
+
+On push to `main` the workflow compiles, runs tests, then:
+- If tag `v<version>` does **not** exist → packages the `.vsix`, publishes to Open VSX, and creates a GitHub release `v<version>`.
+- If the version was **not** changed in the push → skips publishing (normal for docs-only merges).
+- If the version **was** changed but `v<version>` already exists → **fails the build** (guards against bumping to an already-published version, which would otherwise silently skip publishing while the job still reports success).
+
+Notes:
+- Open VSX takes a minute or two to serve the new version after publish. Verify the *artifact*, not just the version string returned by the API — download it and confirm the change is present.
+- Publishing uses the `OPEN_VSX_REGISRY_TOKEN` repo secret.
+
 ## Future work items
-- add the ability to publish the extension from CI. vsce tool let’s you do package and publish. If you do publish there is a signing step that happens, keys to setup, etc. If you don’t do that, you package it in CI or local and upload it in the extension marketplace.
 - Add buildkite CI support and add proper testing
 
 Improve screenshot gif


### PR DESCRIPTION
Bumping `package.json` to a version whose tag already exists caused the release workflow to silently skip Package/Publish/Create-Release while still reporting success — the change never reached Open VSX (exactly what happened with 0.0.40).

Adds a guard: detect whether the version changed in the push, and if it did but `v<version>` already exists, fail the build. No-bump pushes (docs, etc.) still skip publishing as before, so this does not break non-release merges.

Also documents the release process in `dev.md` and removes the now-done "publish from CI" future-work item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)